### PR TITLE
Include full url in `loc` field

### DIFF
--- a/index.js
+++ b/index.js
@@ -322,8 +322,6 @@ module.exports = {
         const locale = page.workflowLocale || defaultLocale;
 
         if (!self.excludeTypes.includes(page.type)) {
-          let url;
-
           // TODO: Revisit when supporting text format
           if (self.format === 'text') {
             if (self.indent) {
@@ -336,7 +334,6 @@ module.exports = {
               self.write(locale, page._url + '\n');
             }
           } else {
-            url = page._url;
             let priority = (page.level < 10) ? (1.0 - page.level / 10) : 0.1;
 
             if (typeof (page.siteMapPriority) === 'number') {
@@ -347,7 +344,7 @@ module.exports = {
               url: {
                 priority: priority,
                 changefreq: 'daily',
-                loc: url
+                loc: self.baseUrl + self.apos.prefix + page._url
               }
             });
           }


### PR DESCRIPTION
**edit: This issue only applies when the `baseUrl` is defined as a module option  instead of a root app.js configuration**

The `<loc>` field contained just the path, instead of (what it should be) the full url.

My changes would make the following correction to a `sitemap.xml` file:

```diff
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
  <url>
    <priority>1</priority>
    <changefreq>daily</changefreq>
-    <loc>/</loc>
+    <loc>https://foo.com/</loc>
  </url>
  <url>
    <priority>0.9</priority>
    <changefreq>daily</changefreq>
-    <loc>/new-page</loc>
+    <loc>https://foo.com/new-page</loc>
  </url>
</urlset>
```