### PR TITLE
Fix support for baseURL override through plugin options

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,14 @@ module.exports = {
 
     self.baseUrl = options.baseUrl || self.apos.baseUrl;
 
+    if ('baseUrl' in options && options.baseUrl) {
+      self.baseUrl = options.baseUrl;
+      self.baseUrlOverridden = true;
+    } else {
+      self.baseUrl = self.apos.baseUrl;
+      self.baseUrlOverridden = false;
+    }
+
     if (!self.baseUrl) {
       throw new Error(noBaseUrlWarning);
     }
@@ -336,7 +344,17 @@ module.exports = {
               self.write(locale, page._url + '\n');
             }
           } else {
-            url = page._url;
+            if (self.baseUrlOverridden) {
+              try {
+                const parsedUrl = new URL(page._url);
+                url = self.baseUrl + parsedUrl.pathname;
+              } catch (error) {
+                url = page._url;
+              }
+            } else {
+              url = page._url;
+            }
+
             let priority = (page.level < 10) ? (1.0 - page.level / 10) : 0.1;
 
             if (typeof (page.siteMapPriority) === 'number') {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Adds the ability to override the baseUrl through the module options. Closes #4 

## What are the specific steps to test this change?

> 1.  Set the APOS_BASE_URL environment variable -OR - baseUrl configuration value
> 2. Run `node app @apostrophecms/sitemap:print` and see that the sitemap includes the baseUrl in page URLs
> 3. Add a different baseUrl value in the module options object
> 4. Run `node app @apostrophecms/sitemap:print` again, and see that the module's config option is used instead

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
This feature is helpful when running Apostrophe in docker or behind a proxy, where the baseUrl may internally be localhost.
